### PR TITLE
Set the image container height and width to equal device width. Since…

### DIFF
--- a/.expo/packager-info.json.1065503039
+++ b/.expo/packager-info.json.1065503039
@@ -1,9 +1,9 @@
 {
   "devToolsPort": 19002,
-  "expoServerPort": 19000,
+  "expoServerPort": null,
   "packagerPort": 19001,
-  "packagerPid": 13272,
+  "packagerPid": 9860,
   "expoServerNgrokUrl": "https://x3-dnc.cjaponte.frontend-mobile.exp.direct",
   "packagerNgrokUrl": "https://packager.x3-dnc.cjaponte.frontend-mobile.exp.direct",
-  "ngrokPid": 15552
+  "ngrokPid": 11736
 }

--- a/components/UploadMedia.js
+++ b/components/UploadMedia.js
@@ -27,7 +27,8 @@ class UploadMedia extends Component {
     let result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ImagePicker.MediaTypeOptions.All,
       allowsEditing: true,
-      aspect: [1, 1]
+      aspect: [1, 1],
+      quality: 1
     });
     // console.log(result, 'Pick Image ----------------------------------');
     if (!result.cancelled) {

--- a/constants/FeedScreen/FeedCampaign.js
+++ b/constants/FeedScreen/FeedCampaign.js
@@ -33,8 +33,9 @@ export default {
   },
   campImgContain: {
     /* Must have a Width && Height or it won't display anything! */
-    resizeMode: 'contain',
-    height: deviceWidth <= 415 ? deviceWidth : 415
+    flex: 1,
+    height: deviceWidth,
+    width: deviceWidth,
   },
   goToCampaignButton: {
     backgroundColor: '#00FF9D',

--- a/constants/FeedScreen/FeedUpdate.js
+++ b/constants/FeedScreen/FeedUpdate.js
@@ -14,8 +14,9 @@ export default {
   },
   campImgContain: { 
     /* Must have a Width && Height or it won't display anything! */
-    resizeMode: 'contain',
-    height: deviceWidth <= 415 ? deviceWidth : 415
+    flex: 1,
+    height: deviceWidth,
+    width: deviceWidth,
   },
   goToCampaignButton: {  
     backgroundColor: '#00FF9D',

--- a/constants/screens/ViewCampScreen.js
+++ b/constants/screens/ViewCampScreen.js
@@ -56,8 +56,11 @@ export default {
   },
   campImgContain: {
     /* Must have a Width && Height or it won't display anything! */
-    resizeMode: 'contain',
-    height: deviceWidth <= 415 ? deviceWidth : 415
+    // resizeMode: 'contain',
+    // height: deviceWidth <= 415 ? deviceWidth : 415
+    flex: 1,
+    height: deviceWidth,
+    width: deviceWidth,
   },
   campDescContain: {
     marginLeft: 15,

--- a/screens/FeedScreen.js
+++ b/screens/FeedScreen.js
@@ -14,7 +14,7 @@ class FeedScreen extends React.Component {
     return {
       title: 'Feed',
       headerStyle: {
-        backgroundColor: '#323338'
+        backgroundColor: '#000000'
       },
       headerTintColor: '#fff',
       headerTitleStyle: {

--- a/screens/ViewCampScreen.js
+++ b/screens/ViewCampScreen.js
@@ -21,7 +21,7 @@ import styles from '../constants/screens/ViewCampScreen'
 class ViewCampScreen extends React.Component {
   static navigationOptions = ({ navigation }) => {
     return {
-      title: 'Campaign',
+      title: 'Campaignz',
       headerStyle: {
         backgroundColor: '#323338'
       },

--- a/screens/ViewCampUpdateScreen.js
+++ b/screens/ViewCampUpdateScreen.js
@@ -140,8 +140,11 @@ const styles = StyleSheet.create({
   },  
   campImgContain: {
     /* Must have a Width && Height or it won't display anything! */
-    resizeMode: 'contain',
-    height: deviceWidth <= 415 ? deviceWidth : 415
+    // resizeMode: 'contain',
+    // height: deviceWidth <= 415 ? deviceWidth : 415
+    flex: 1,
+    height: deviceWidth,
+    width: deviceWidth,
   },
   campDescContain: {
     marginLeft: 15,


### PR DESCRIPTION
… when users upload an image, they have to crop it in a square shape, the height and width being the same work perfectly.

# Description

Describe change or new feature here.

## Checklist

Remove any items which are not applicable.

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works AND the tests pass
